### PR TITLE
[고도화] equals and hashcode refactoring

### DIFF
--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/Article.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/Article.java
@@ -61,12 +61,12 @@ public class Article extends AuditingFields{
     @Override
     public boolean equals(Object object) {
         if (this == object) return true;
-        if (!(object instanceof Article article)) return false;
-        return id != null && Objects.equals(id, article.id);
+        if (!(object instanceof Article that)) return false;
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
@@ -53,11 +53,11 @@ public class ArticleComment extends AuditingFields{
     public boolean equals(Object object) {
         if (this == object) return true;
         if (!(object instanceof ArticleComment that)) return false;
-        return id != null && Objects.equals(id, that.id);
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
@@ -57,11 +57,11 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object object) {
         if (this == object) return true;
         if (!(object instanceof UserAccount that)) return false;
-        return Objects.equals(userId, that.userId);
+        return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
equals() , hashcode() 가 값을 비교하기 위해 필드 직접 접근 하는 것을 getter로 바꾼다.
프록시 객체를 사용하는 하이버네이트의 지연로딩을 고려하여, 값 비교를 제대로 수행 하지 못하는 일이 없도록 한다.