### PR TITLE
#67 - 대댓글 비지니스 로직 구현 및 댓글 컨트롤러 테스트 업데이트

### DIFF
--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/dto/ArticleCommentDto.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/dto/ArticleCommentDto.java
@@ -14,31 +14,36 @@ public record ArticleCommentDto(
         Long id,
         Long articleId,
         UserAccountDto userAccountDto,
+        Long parentCommentId,
         String content,
         LocalDateTime createdAt,
         String createdBy,
         LocalDateTime modifiedAt,
         String modifiedBy){
+
     public static ArticleCommentDto of(Long id,
                                        Long articleId,
                                        UserAccountDto userAccountDto,
+                                       Long parentCommentId,
                                        String content,
                                        LocalDateTime createdAt,
                                        String createdBy,
                                        LocalDateTime modifiedAt,
                                        String modifiedBy) {
-        return new ArticleCommentDto(id, articleId, userAccountDto, content, createdAt, createdBy, modifiedAt, modifiedBy);
+        return new ArticleCommentDto(id, articleId, userAccountDto, parentCommentId, content, createdAt, createdBy, modifiedAt, modifiedBy);
     }
 
-    public static ArticleCommentDto of(Long articleId, UserAccountDto userAccountDto, String content) {
-        return new ArticleCommentDto(null, articleId, userAccountDto, content, null, null, null, null);
+    public static ArticleCommentDto of(Long articleId, UserAccountDto userAccountDto , Long parentCommentId , String content) {
+        return ArticleCommentDto.of(null, articleId, userAccountDto, parentCommentId, content, null, null, null, null);
     }
+
 
     public static ArticleCommentDto from(ArticleComment entity){
         return new ArticleCommentDto(
                 entity.getId() ,
                 entity.getArticle().getId(),
                 UserAccountDto.from(entity.getUserAccount()),
+                entity.getParentCommentId(),
                 entity.getContent(),
                 entity.getCreatedAt(),
                 entity.getCreatedBy(),

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/dto/request/ArticleCommentRequest.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/dto/request/ArticleCommentRequest.java
@@ -8,14 +8,19 @@ import com.fastcampus.projectboard.dto.UserAccountDto;
  */
 public record ArticleCommentRequest(
         Long articleId,
+        Long parentCommentId,
         String content
 ){
 
     public static ArticleCommentRequest of(Long articleId, String content) {
-        return new ArticleCommentRequest(articleId, content);
+        return new ArticleCommentRequest(articleId, null ,content);
+    }
+
+    public static ArticleCommentRequest of(Long articleId, Long parentCommentId , String content) {
+        return new ArticleCommentRequest(articleId, parentCommentId , content);
     }
 
     public ArticleCommentDto toDto(UserAccountDto userAccountDto){
-        return ArticleCommentDto.of(articleId, userAccountDto, content);
+        return ArticleCommentDto.of(articleId, userAccountDto, parentCommentId ,content);
     }
 }

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/dto/response/ArticleCommentsResponse.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/dto/response/ArticleCommentsResponse.java
@@ -2,8 +2,10 @@ package com.fastcampus.projectboard.dto.response;
 
 import com.fastcampus.projectboard.dto.ArticleCommentDto;
 
-
 import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * DTO for {@link com.fastcampus.projectboard.domain.ArticleComment}
@@ -14,10 +16,23 @@ public record ArticleCommentsResponse(
         LocalDateTime createdAt,
         String email ,
         String nickname,
-        String userId
-){
-    public static ArticleCommentsResponse of (Long id, String content, LocalDateTime createdAt, String email, String nickname , String userId) {
-        return new ArticleCommentsResponse(id, content, createdAt, email, nickname,userId);
+        String userId,
+        Long parentCommentId,
+        Set<ArticleCommentsResponse> childComments
+        ){
+
+    // 자식 댓글이 없는 경우
+    public static ArticleCommentsResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname, String userId) {
+        return ArticleCommentsResponse.of(id, content, createdAt, email, nickname, userId, null);
+    }
+
+    // 자식 댓글이 있는 경우
+    public static ArticleCommentsResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname, String userId, Long parentCommentId) {
+        Comparator<ArticleCommentsResponse> childCommentComparator =
+                Comparator.comparing(ArticleCommentsResponse::createdAt)
+                        .thenComparingLong(ArticleCommentsResponse::id);
+
+        return new ArticleCommentsResponse(id, content, createdAt, email, nickname, userId, parentCommentId, new TreeSet<>(childCommentComparator));
     }
 
     public static ArticleCommentsResponse from(ArticleCommentDto dto) {
@@ -26,14 +41,18 @@ public record ArticleCommentsResponse(
             nickname = dto.userAccountDto().userId();
         }
 
-        return new ArticleCommentsResponse(
+        return ArticleCommentsResponse.of(
                 dto.id(),
                 dto.content(),
                 dto.createdAt(),
                 dto.userAccountDto().email(),
                 nickname,
-                dto.userAccountDto().userId()
+                dto.userAccountDto().userId(),
+                dto.parentCommentId()
         );
     }
 
+    public boolean hasParentComment(){
+        return parentCommentId != null;
+    }
 }

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/dto/response/ArticleWithCommentsResponse.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/dto/response/ArticleWithCommentsResponse.java
@@ -1,17 +1,20 @@
 package com.fastcampus.projectboard.dto.response;
 
 import com.fastcampus.projectboard.domain.Article;
+import com.fastcampus.projectboard.dto.ArticleCommentDto;
 import com.fastcampus.projectboard.dto.ArticleWithCommentsDto;
 import com.fastcampus.projectboard.dto.HashtagDto;
 
 
 import java.time.LocalDateTime;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
  * DTO for {@link Article}
+ * 게시글과 댓글이 같이 있는 response -> ArticleCommentsResponse 로 댓글들 응답
+ * ArticleCommentsResponse 에 부모 아이디와 자식 댓글 객체들 담을 수 있게 설정
  */
 public record ArticleWithCommentsResponse(
         Long id,
@@ -24,7 +27,15 @@ public record ArticleWithCommentsResponse(
         String userId,
         Set<ArticleCommentsResponse> articleCommentResponses
 ){
-    public static ArticleWithCommentsResponse of(Long id, String title, String content, Set<String> hashtags, LocalDateTime createdAt, String email, String nickname, String userId, Set<ArticleCommentsResponse> articleCommentResponses ) {
+    public static ArticleWithCommentsResponse of(Long id,
+                                                 String title,
+                                                 String content,
+                                                 Set<String> hashtags,
+                                                 LocalDateTime createdAt,
+                                                 String email,
+                                                 String nickname,
+                                                 String userId,
+                                                 Set<ArticleCommentsResponse> articleCommentResponses ) {
         return new ArticleWithCommentsResponse(id, title, content, hashtags, createdAt, email, nickname, userId , articleCommentResponses);
     }
 
@@ -33,12 +44,46 @@ public record ArticleWithCommentsResponse(
         if (nickname == null || nickname.isBlank()) {
             nickname = dto.userAccountDto().userId();
         }
-        return new ArticleWithCommentsResponse(dto.id()  , dto.title() , dto.content() , dto.hashtagDtos().stream().map(HashtagDto::hashtagName).collect(Collectors.toUnmodifiableSet()) , dto.createdAt() ,
-                dto.userAccountDto().email(), nickname,
+        return new ArticleWithCommentsResponse(
+                dto.id(),
+                dto.title(),
+                dto.content(),
+                dto.hashtagDtos().stream().map(HashtagDto::hashtagName).collect(Collectors.toUnmodifiableSet()),
+                dto.createdAt(),
+                dto.userAccountDto().email(),
+                nickname,
                 dto.userAccountDto().userId(),
-                dto.articleCommentsDto().stream().map(ArticleCommentsResponse::from)
-                        .collect(Collectors.toCollection(LinkedHashSet::new))
-                );
+                organizeChildComments(dto.articleCommentsDto())
+        );
     }
 
+    /*
+    * 자식 comment 정렬
+    * */ //DTO 에서 ArticleCommentsResponse 로 변환
+    private static Set<ArticleCommentsResponse> organizeChildComments(Set<ArticleCommentDto> dtos){
+        // DTO 에서 받은 댓글 response 로 변환하여 Map 으로 정렬
+
+        Map<Long, ArticleCommentsResponse> map = dtos.stream()
+                .map(ArticleCommentsResponse::from)
+                .collect(Collectors.toMap(ArticleCommentsResponse::id,
+                        Function.identity()));
+
+        // Response 에서 부모가 있는 댓글 찾아서 자식 댓글 추가
+        map.values().stream()
+                .filter(ArticleCommentsResponse::hasParentComment)
+                .forEach(comment -> {
+                    ArticleCommentsResponse parentComment =
+                            map.get(comment.parentCommentId());
+
+                    parentComment.childComments().add(comment);
+                });
+
+        // 최상위 댓글들을 시간순 , id 순으로 정렬
+        return map.values().stream()
+                .filter(comment -> !comment.hasParentComment())
+                .collect(Collectors.toCollection(() ->
+                        new TreeSet<>(Comparator.comparing(ArticleCommentsResponse::createdAt).
+                                reversed().thenComparingLong(ArticleCommentsResponse::id))));
+
+    }
 }

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/service/ArticleCommentService.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/service/ArticleCommentService.java
@@ -37,7 +37,18 @@ public class ArticleCommentService {
             Article article = articleRepository.getReferenceById(dto.articleId());
             UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
 
-            articleCommentRepository.save(dto.toEntity(article, userAccount));
+
+            ArticleComment articleComment = dto.toEntity(article, userAccount);
+
+
+            if (dto.parentCommentId() != null) {
+                ArticleComment parentComment = articleCommentRepository.getReferenceById(dto.parentCommentId());
+                parentComment.addChildComment(articleComment);
+
+            }
+            else{
+                articleCommentRepository.save(articleComment);
+            }
 
         } catch (EntityNotFoundException e) {
             log.warn("댓글 저장 실패. 댓글 작성에 필요한 정보를 찾을 수 없습니다 - {}", e.getLocalizedMessage());

--- a/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/controller/ArticleCommentControllerTest.java
+++ b/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/controller/ArticleCommentControllerTest.java
@@ -22,10 +22,11 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 
 @DisplayName("View 컨트롤러 - 댓글")
@@ -38,7 +39,7 @@ class ArticleCommentControllerTest {
     @MockBean
     private ArticleCommentService articleCommentService;
 
-    ArticleCommentControllerTest(@Autowired  MockMvc mvc, @Autowired FormDataEncoder formDataEncoder) {
+    ArticleCommentControllerTest(@Autowired MockMvc mvc, @Autowired FormDataEncoder formDataEncoder) {
         this.mvc = mvc;
         this.formDataEncoder = formDataEncoder;
     }
@@ -53,10 +54,10 @@ class ArticleCommentControllerTest {
         willDoNothing().given(articleCommentService).saveArticleComment(any(ArticleCommentDto.class));
 
         // When & Then
-        mvc.perform(MockMvcRequestBuilders.post("/comments/new")
-                                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                                .content(formDataEncoder.encode(request))
-                                .with(csrf()))
+        mvc.perform(post("/comments/new")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content(formDataEncoder.encode(request))
+                        .with(csrf()))
                 .andExpect(view().name("redirect:/articles/" + articleId))
                 .andExpect(redirectedUrl("/articles/" + articleId));
         BDDMockito.then(articleCommentService).should().saveArticleComment(any(ArticleCommentDto.class));
@@ -72,11 +73,11 @@ class ArticleCommentControllerTest {
         long articleCommentId = 1L;
         String userId = "unoTest";
 
-        willDoNothing().given(articleCommentService).deleteArticleComment(articleCommentId,userId);
+        willDoNothing().given(articleCommentService).deleteArticleComment(articleCommentId, userId);
 
         // When & Then
         mvc.perform(
-                        MockMvcRequestBuilders.post("/comments/" + articleCommentId + "/delete")
+                        post("/comments/" + articleCommentId + "/delete")
                                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                                 .content(formDataEncoder.encode(Map.of("articleId", articleId)))
                                 .with(csrf())
@@ -84,6 +85,26 @@ class ArticleCommentControllerTest {
                 .andExpect(MockMvcResultMatchers.status().is3xxRedirection())
                 .andExpect(view().name("redirect:/articles/" + articleId))
                 .andExpect(redirectedUrl("/articles/" + articleId));
-        BDDMockito.then(articleCommentService).should().deleteArticleComment(articleCommentId,userId);
+        BDDMockito.then(articleCommentService).should().deleteArticleComment(articleCommentId, userId);
+    }
+
+    @WithUserDetails(value = "unoTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("[view][Post] 대댓글 등록 - 정상 호출")
+    @Test
+    public void givenArticleCommentInfoWithParentCommentId_whenRequesting_thenSavesNewChildComment() throws Exception {
+        long articleId = 1L;
+        ArticleCommentRequest request = ArticleCommentRequest.of(articleId, 1L, "test comment");
+
+        willDoNothing().given(articleCommentService).saveArticleComment(any(ArticleCommentDto.class));
+
+        mvc.perform(
+                post("/comments/new")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content(formDataEncoder.encode(request))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/articles/" + articleId))
+                .andExpect(redirectedUrl("/articles/" + articleId));
+        then(articleCommentService).should().saveArticleComment(any(ArticleCommentDto.class));
     }
 }

--- a/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/dto/response/ArticleWithCommentsResponseTest.java
+++ b/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/dto/response/ArticleWithCommentsResponseTest.java
@@ -1,0 +1,177 @@
+package com.fastcampus.projectboard.dto.response;
+
+import com.fastcampus.projectboard.dto.ArticleCommentDto;
+import com.fastcampus.projectboard.dto.ArticleWithCommentsDto;
+import com.fastcampus.projectboard.dto.HashtagDto;
+import com.fastcampus.projectboard.dto.UserAccountDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Iterator;
+import java.util.Set;
+
+@DisplayName("DTO - 댓글들을 포함한 게시글 응답 테스트")
+class ArticleWithCommentsResponseTest {
+    @DisplayName("자식 댓글이 없는 게시글 + 댓글 dto를 api 응답으로 변환할 때, 댓글을 시간 내림차순 + ID 오름차순으로 정리한다.")
+    @Test
+    void givenArticleWithCommentsDtoWithoutChildComments_whenMapping_thenOrganizesCommentsWithCertainOrder() {
+        LocalDateTime now = LocalDateTime.now();
+        Set<ArticleCommentDto> articleCommentDtos =
+                Set.of(createArticleCommentDto(1L, null, now),
+                        createArticleCommentDto(2L, null, now.plusDays(1L)),
+                        createArticleCommentDto(3L, null, now.plusDays(3L)),
+                        createArticleCommentDto(4L, null, now),
+                        createArticleCommentDto(5L, null, now.plusDays(5L)),
+                        createArticleCommentDto(6L, null, now.plusDays(4L)),
+                        createArticleCommentDto(7L, null, now.plusDays(2L)),
+                        createArticleCommentDto(8L, null, now.plusDays(7L))
+                );
+
+        ArticleWithCommentsDto input = createArticleWithCommentsDto(articleCommentDtos);
+        // 댓글 여러개 생성하고 게시물과 함께 있는 댓글 DTO 생성
+
+        ArticleWithCommentsResponse actual = ArticleWithCommentsResponse.from(input);
+        // 댓글 여러개 생성한 DTO를 Response 로 변환 (response 는 comment dto 객체를 받아
+        //
+
+        Assertions.assertThat(actual.articleCommentResponses())
+                .containsExactly(
+                        createArticleCommentResponse(8L, null, now.plusDays(7L)),
+                        createArticleCommentResponse(5L, null, now.plusDays(5L)),
+                        createArticleCommentResponse(6L, null, now.plusDays(4L)),
+                        createArticleCommentResponse(3L, null, now.plusDays(3L)),
+                        createArticleCommentResponse(7L, null, now.plusDays(2L)),
+                        createArticleCommentResponse(2L, null, now.plusDays(1L)),
+                        createArticleCommentResponse(1L, null, now),
+                        createArticleCommentResponse(4L, null, now));
+    }
+
+    @DisplayName("게시글 + 댓글 dto를 api 응답으로 변환할 때, 댓글 부모 자식 관계를 각각의 규칙으로 정렬하여 정리한다.")
+    @Test
+    void givenArticleWithCommentsDto_whenMapping_thenOrganizesParentAndChildCommentsWithCertainOrders() {
+        LocalDateTime now = LocalDateTime.now();
+        Set<ArticleCommentDto> articleCommentDtos =
+                Set.of(
+                        createArticleCommentDto(1L, null, now),
+                        createArticleCommentDto(2L, 1L, now.plusDays(1L)),
+                        createArticleCommentDto(3L, 1L, now.plusDays(3L)),
+                        createArticleCommentDto(4L, 1L, now),
+                        createArticleCommentDto(5L, null, now.plusDays(5L)),
+                        createArticleCommentDto(6L, null, now.plusDays(4L)),
+                        createArticleCommentDto(7L, 6L, now.plusDays(2L)),
+                        createArticleCommentDto(8L, 6L, now.plusDays(7L))
+                        );
+        ArticleWithCommentsDto input = createArticleWithCommentsDto(articleCommentDtos);
+
+        ArticleWithCommentsResponse actual = ArticleWithCommentsResponse.from(input);
+        Assertions.assertThat(actual.articleCommentResponses())
+                .containsExactly(
+                        createArticleCommentResponse(5L, null, now.plusDays(5)),
+                        createArticleCommentResponse(6L, null, now.plusDays(4)),
+                        createArticleCommentResponse(1L, null, now)
+                        )
+                .flatExtracting(ArticleCommentsResponse::childComments)
+                .containsExactly(
+                        createArticleCommentResponse(7L, 6L, now.plusDays(2L)),
+                        createArticleCommentResponse(8L, 6L, now.plusDays(7L)),
+                        createArticleCommentResponse(4L, 1L, now),
+                        createArticleCommentResponse(2L, 1L, now.plusDays(1L)),
+                        createArticleCommentResponse(3L, 1L, now.plusDays(3L))
+                );
+    }
+
+    @DisplayName("게시글 + 댓글 dto를 api 응답으로 변환할 때, 부모 자식 관계 깊이(depth)는 제한이 없다.")
+    @Test
+    void givenArticleWithCommentsDto_whenMapping_thenOrganizesParentAndChildCommentsWithoutDepthLimit() {
+        LocalDateTime now = LocalDateTime.now();
+        Set<ArticleCommentDto> articleCommentDtos
+                = Set.of(
+                createArticleCommentDto(1L, null, now),
+                createArticleCommentDto(2L, 1L, now.plusDays(1L)),
+                createArticleCommentDto(3L, 2L, now.plusDays(2L)),
+                createArticleCommentDto(4L, 3L, now.plusDays(3L)),
+                createArticleCommentDto(5L, 4L, now.plusDays(4L)),
+                createArticleCommentDto(6L, 5L, now.plusDays(5L)),
+                createArticleCommentDto(7L, 6L, now.plusDays(6L)),
+                createArticleCommentDto(8L, 7L, now.plusDays(7L))
+        );
+
+        ArticleWithCommentsDto input = createArticleWithCommentsDto(articleCommentDtos);
+
+        ArticleWithCommentsResponse actual = ArticleWithCommentsResponse.from(input);
+
+        Iterator<ArticleCommentsResponse> iterator =
+                actual.articleCommentResponses().iterator();
+
+        long i = 1L;
+        while (iterator.hasNext()) {
+            ArticleCommentsResponse articleCommentsResponse
+                    = iterator.next();
+
+            Assertions.assertThat(articleCommentsResponse)
+                    .hasFieldOrPropertyWithValue("id", i)
+                    .hasFieldOrPropertyWithValue("parentCommentId", i == 1L ? null : i - 1L)
+                    .hasFieldOrPropertyWithValue("createdAt", now.plusDays(i - 1L));
+
+            iterator = articleCommentsResponse.childComments().iterator();
+            i++;
+        }
+    }
+
+
+    private ArticleCommentsResponse createArticleCommentResponse(Long id ,
+                                                                 Long parentId ,
+                                                                 LocalDateTime createdAt) {
+        return ArticleCommentsResponse.of(id,
+                "test comment " + id,
+                createdAt,
+                "uno@mail.com",
+                "Uno",
+                "uno",
+                parentId);
+    }
+
+    private ArticleWithCommentsDto createArticleWithCommentsDto(Set<ArticleCommentDto> articleCommentDtos) {
+        return ArticleWithCommentsDto.of(
+                1L,
+                createUserAccountDto(),
+                articleCommentDtos,
+                "title",
+                "content",
+                Set.of(HashtagDto.of("java")),
+                LocalDateTime.now(),
+                "uno",
+                LocalDateTime.now(),
+                "uno");
+    }
+
+    private ArticleCommentDto createArticleCommentDto(long id, Long parentCommentId, LocalDateTime createdAt) {
+        return ArticleCommentDto.of(
+                id,
+                1L,
+                createUserAccountDto(),
+                parentCommentId,
+                "test comment " + id,
+                createdAt,
+                "uno",
+                createdAt,
+                "uno");
+    }
+
+
+    private UserAccountDto createUserAccountDto() {
+        return UserAccountDto.of(
+                "uno",
+                "password",
+                "uno@mail.com",
+                "Uno",
+                "This is memo",
+                LocalDateTime.now(),
+                "uno",
+                LocalDateTime.now(),
+                "uno");
+    }
+
+}


### PR DESCRIPTION
이 pr 은 대댓글을 저장, 삭제하기 위한  기능을 추가한다.
This closes #67 